### PR TITLE
Amend: Swap n-teaser from bower to npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,5 @@
     "bower_components",
     "test",
     "tests"
-  ],
-  "dependencies": {
-    "n-teaser": "^0.2.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "git+https://github.com/Financial-Times/n-teaser-collection.git"
   },
   "license": "MIT",
+  "dependencies": {
+    "@financial-times/n-teaser": "^1.0.0"
+  },
   "devDependencies": {
     "bower": "^1.7.9",
     "npm-prepublish": "^1.2.1"


### PR DESCRIPTION
@keirog 

Would need to be a major release (v1.0.0)

Swaps the bower required for the preferred method of requiring nTeaser from (v1.0.0 of nTeaser) to be via npm.