### PR TITLE
a11y issue (DAC_TECH_Validation _Issue)

### DIFF
--- a/templates/partials/heading.html
+++ b/templates/partials/heading.html
@@ -1,13 +1,13 @@
 {{#if title}}
 	{{#if hideTitle}}
-		<h2 class="n-util-visually-hidden">{{title}}</h2>
+		<h3 id="suggested-reads__title" class="n-util-visually-hidden">{{title}}</h3>
 	{{else}}
-		<h2 class="o-teaser-collection__heading{{#headingModifiers}} o-teaser-collection__heading--{{this}}{{/headingModifiers}}">
+		<h3 id="suggested-reads__title" class="o-teaser-collection__heading{{#headingModifiers}} o-teaser-collection__heading--{{this}}{{/headingModifiers}}">
 			{{#if url}}
 				<a href="{{url}}" data-trackable="section-title">{{title}}</a>
 			{{else}}
 				{{title}}
 			{{/if}}
-		</h2>
+		</h3>
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
@keirog @i-like-robots, I need a sanity check on this one if you have some time. Hoping to solve the following issue: 

<img width="418" alt="screen shot 2016-12-11 at 18 38 05" src="https://cloud.githubusercontent.com/assets/3425322/21082315/3549eb62-bfd1-11e6-853d-9b7105731877.png">

https://github.com/search?utf8=%E2%9C%93&q=user%3AFinancial-Times+suggested-reads__title&type=Code&ref=searchresults

suggested-reads.html had the id, but suggested-reads-teaser-collection.html didn't. 

(While I was in there, I've made the headings `h3`s to match suggested-reads.html and lighten the load of `h2`s)