### PR TITLE
more than one of these per page

### DIFF
--- a/templates/partials/heading.html
+++ b/templates/partials/heading.html
@@ -1,8 +1,8 @@
 {{#if title}}
 	{{#if hideTitle}}
-		<div id="suggested-reads__title" class="n-util-visually-hidden">{{title}}</div>
+		<div class="n-util-visually-hidden">{{title}}</div>
 	{{else}}
-		<div id="suggested-reads__title" class="o-teaser-collection__heading{{#headingModifiers}} o-teaser-collection__heading--{{this}}{{/headingModifiers}}">
+		<div class="o-teaser-collection__heading{{#headingModifiers}} o-teaser-collection__heading--{{this}}{{/headingModifiers}}">
 			{{#if url}}
 				<a href="{{url}}" data-trackable="section-title">{{title}}</a>
 			{{else}}


### PR DESCRIPTION
@keirog I added this a while back to fix an a11y issue (a labelledby that was pointing to a nonexistent id in article) and it's just popped up now that it results in several elements on the page having the same ID 😬  I think it's because I've only now released the component. 