### PR TITLE
Add action styles back in

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "n-teaser-collection",
   "homepage": "https://github.com/financial-times/n-teaser-collection",
   "description": "A set of layouts for groups of n-teasers",
+  "main": [
+    "main.scss"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",

--- a/main.scss
+++ b/main.scss
@@ -1,0 +1,5 @@
+.o-teaser-collection--stream .o-teaser__action {
+    position: absolute;
+    right: 0;
+    top: 0;
+}


### PR DESCRIPTION
This was removed in `o-teaser-collection` - https://github.com/Financial-Times/o-teaser-collection#deprecated-v1-styles

I have no idea why, or what the expected solution is, but this fixes it for now