### PR TITLE
Remove out of date n-teaser dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "url": "git+https://github.com/Financial-Times/n-teaser-collection.git"
   },
   "license": "MIT",
-  "dependencies": {
-    "@financial-times/n-teaser": "^1.0.0"
-  },
   "devDependencies": {
     "@financial-times/n-gage": "^1.1.7",
     "bower": "^1.7.9",


### PR DESCRIPTION
This will be released as a new breaking change.

Removing this dependency as it is causing clashes and also resulting in a larger than necessary client side js bundle. 

If you are using this module you will also need to included n-teaser in the project.

I am removing this and releasing as a breaking change because I can see other projects that are only requiring this module and not n-teaser.