### PR TITLE
Add o-normalise-class to hidden headings

### DIFF
--- a/templates/partials/heading.html
+++ b/templates/partials/heading.html
@@ -1,6 +1,6 @@
 {{#if title}}
 	{{#if hideTitle}}
-		<div class="n-util-visually-hidden">{{{title}}}</div>
+		<div class="o-normalise-visually-hidden n-util-visually-hidden">{{{title}}}</div>
 	{{else}}
 		<{{#if headingTag}}{{headingTag}}{{else}}div{{/if}} class="o-teaser-collection__heading{{#headingModifiers}} o-teaser-collection__heading--{{this}}{{/headingModifiers}}"{{#if ariaLabel}} aria-label="{{ariaLabel}}"{{/if}}>
 			{{#if url}}


### PR DESCRIPTION
I think this is only used on the front page, so going to release like this as a patch, and then remove the old class once front page updated.